### PR TITLE
LeaderboardItem: Improvements on overflowing elements

### DIFF
--- a/src/components/LeaderboardItem.svelte
+++ b/src/components/LeaderboardItem.svelte
@@ -49,6 +49,7 @@
         border-radius: 50%;
         height: 50px;
         margin-right: 10px;
+        flex-shrink: 0;
     }
     .top-name {
         margin-left: inherit;

--- a/src/components/LeaderboardItem.svelte
+++ b/src/components/LeaderboardItem.svelte
@@ -41,6 +41,8 @@
         padding: 8px;
         align-items: center;
         display: flex;
+        min-width: 0;
+        width: 100%;
     }
     .top-item:last-child {
         border-bottom: 0;
@@ -53,6 +55,14 @@
     }
     .top-name {
         margin-left: inherit;
+        display: flex;
+        flex-direction: column;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+    }
+    .top-messages {
+        flex-shrink: 0;
     }
     .top-bubble {
         align-items: center;


### PR DESCRIPTION
This is what the website used to look like with such element.
![Screenshot (182)](https://user-images.githubusercontent.com/29630035/122198437-7436d200-ce99-11eb-87d6-6c23da94f1aa.png)

Now, with these changes, it looks like this:
![Screenshot (181)](https://user-images.githubusercontent.com/29630035/122198394-6aad6a00-ce99-11eb-8153-a51e3d326cf6.png)