### PR TITLE
🚀 Add Docker deploy support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
-FROM node:14
-WORKDIR /usr/local/app
+FROM node:14 AS build
+WORKDIR /usr/local/ddpe
 COPY . .
-RUN yarn install
-CMD ["yarn", "dev"]
+RUN yarn install && yarn build
+
+FROM nginx
+COPY --from=build /usr/local/ddpe/public /usr/share/nginx/html

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM node:14
+WORKDIR /usr/local/app
+COPY . .
+RUN yarn install
+CMD ["yarn", "dev"]

--- a/README.md
+++ b/README.md
@@ -16,7 +16,12 @@ What's **really** in your Discord Data package? And how can this data be useful?
 * Open **https://ddpe.androz2091.fr**
 * and import your data file!
 
-### Installation
+### Docker
+
+This repository provides a Docker image and compose file. Simply run `docker-compose up -d` in the project directory 
+and you can access the app at http://localhost:5000.
+
+### Manual Installation
 
 Discord Data Package Explorer is built with **[Svelte](https://svelte.dev)**, and is quite easy to install.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
 version: "3.9"
 services:
-  website:
-    environment:
-      - HOST=0.0.0.0
+  web:
     build: .
     ports:
-      - "5000:5000"
+      - "5000:80"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,8 @@
 version: "3.9"
 services:
   website:
+    environment:
+      - HOST=0.0.0.0
     build: .
     ports:
       - "5000:5000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: "3.9"
+services:
+  website:
+    build: .
+    ports:
+      - "5000:5000"


### PR DESCRIPTION
To simplify the installation of own instances of this app, this PR adds a `Dockerfile` specifying a docker image that runs the app as well as a `docker-compose.yml` for convenience. I have updated the "How to use" section in the readme accordingly.

Running the image via `docker-compose up` now guarantees the absence of "works on my machine"-type issues, of which I've had a few with this app in the past as well.