### PR TITLE
:zap: Use nginx alpine image to reduce image size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,5 @@ WORKDIR /usr/local/ddpe
 COPY . .
 RUN yarn install && yarn build
 
-FROM nginx
+FROM nginx:alpine
 COPY --from=build /usr/local/ddpe/public /usr/share/nginx/html


### PR DESCRIPTION
```bash
docker image ls --format '{{.Repository}} - {{.Size}}'
```
```
discord-data-explorer-alpine - 23.7MB
discord-data-explorer - 134MB
// Maybe more images
// ofc you have to build both branches and tag the images to see this like shown here
```
This PR reduces the docker image size from 134 MB to 23.7 MB by using the alpine image of nginx.