### PR TITLE
Add nginx configuration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,5 @@ COPY . .
 RUN yarn install && yarn build
 
 FROM nginx:alpine
+COPY nginx.conf /etc/nginx/nginx.conf
 COPY --from=build /usr/local/ddpe/public /usr/share/nginx/html

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,38 @@
+
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+
+    keepalive_timeout  65;
+
+    gzip  on;
+
+    server {
+        listen       80;
+        listen  [::]:80;
+        root /usr/share/nginx/html;
+        location / {
+            try_files $uri $uri/ /index.html;
+        }
+    }
+}


### PR DESCRIPTION
This PR adds a configuration file for nginx. The history mode routing is not working correctly without this configuration. Every non-index route would be a 404 without this config.