### PR TITLE
Change payment string to better represent total amount

### DIFF
--- a/src/views/Stats.svelte
+++ b/src/views/Stats.svelte
@@ -87,7 +87,7 @@
                         <h3>
                             You spent
                             <span class="text-discord" on:click="{ $data.payments.list.length ? showModal(`<h3 style="text-align: center">${$data.payments.list}</h3>`) : undefined }">
-                                ${ parseInt($data.payments.total).toLocaleString('en-US') }
+                                ${ Math.round($data.payments.total).toLocaleString('en-US') }
                             </span>
                             on Discord
                         </h3>


### PR DESCRIPTION
I changed the way the payment string is converted to an integer to better represent the total amount spent. (e.g. $4.99 now shows as $5 instead of $4)