### PR TITLE
Format message counts in guild channels

### DIFF
--- a/src/views/Stats.svelte
+++ b/src/views/Stats.svelte
@@ -182,7 +182,7 @@
                                 position={i}
                                 name={channel.name}
                                 guild={channel.guildName}
-                                count={channel.messageCount}
+                                count={channel.messageCount.toLocaleString('en-US')}
                                 channel
                             />
                         {/each}


### PR DESCRIPTION
Currently DM message counts are formatted but guild channel message counts are not