### PR TITLE
feat: add umami event on dumpus link

### DIFF
--- a/src/views/Loader.svelte
+++ b/src/views/Loader.svelte
@@ -110,7 +110,7 @@
                     Dumpus - Stats for Discord is released!
                 </p>
                 <div class="app-loader-v2-alert_link-wrapper">
-                    <a href="https://dumpus.app" class="app-loader-v2-alert_link">
+                    <a href="https://dumpus.app" data-umami-event="dumpus-cta" target="_blank" class="app-loader-v2-alert_link">
                     Open
                     <span aria-hidden="true"> &rarr;</span>
                     </a>


### PR DESCRIPTION
1. You might have to manually add the event on umami
2. I added target blank to open in a new tab because I'm afraid that the immediate navigation could prevent sending event