### PR TITLE
Add a written explanation to the help page

### DIFF
--- a/src/views/Help.svelte
+++ b/src/views/Help.svelte
@@ -1,5 +1,15 @@
 <div class="help">
     <div>
+        <ol>
+            <li>Click on "User Settings" in the bottom left corner.</li>
+            <li>Click on "Privacy & Safety".</li>
+            <li>Scroll down to the "Request Data" section at the bottom of the page.</li>
+            <li>Click on "Request Data".</li>
+            <li>Wait for the email from Discord with the download link. 🥳</li>
+        </ol>
+    </div>
+
+    <div>
         Here is a short TikTok video ✨ to show you how to request your Discord Data Package! Note that this is also possible on mobile device using the iOS and Android Discord apps!
     </div>
     <div class="tiktok-player">


### PR DESCRIPTION
This significantly helps with accessibility, and makes it easier to quickly find an explanation instead of needing to watch a video.